### PR TITLE
Propose Subgroups

### DIFF
--- a/docs/subgroups.md
+++ b/docs/subgroups.md
@@ -1,0 +1,25 @@
+# Subgroups
+
+This document is a proposal to create subgroups of the dynamic languages SIG.
+All subgroups will be viewed as a part of SIG-Dynamic-Languages and adhere to all of its rules.
+
+For a subgroup to be formed, there must be two or more members supporting its creation who have agreed to become its organizing members.
+Organizing members are responsible for scheduling and running, meetings and upholding the Bytecode Alliance Code of Conduct.
+
+Only one kind of subgroup is proposed initially, but this may be extended by future proposals.
+
+Subgroups and their organizing members are listed in this document. Any proposed subgroups or changes to the organizing members of a subgroup must be submitted as a PR to the governance repository, placed on the agenda for a SIG-Dynamic-Languages at least a week before its next meeting, and accepted by a vote.
+
+## Language-Specific Subgroups
+
+A language-specific subgroup will be focused on a single programming language ecosystem and
+exist to further the Wasm support for that language.
+
+The language-specific subgroups are
+
+* Python - organized by
+  * Joel Dice (Fermyon)
+  * Kevin Smith (SingleStore)
+* JavaScript & TypeScript (JS/TS) - organized by
+  * Calvin Prewitt (JAF Labs)
+  * Saúl Cabrera (Shopify)


### PR DESCRIPTION
[rendered](https://github.com/bytecodealliance/SIG-Dynamic-Languages/blob/subgroups/docs/subgroups.md)

Propose subgroups as discussed in last meeting to support language-specific meetings with initial subgroups for both Python and JavaScript.