### PR TITLE
Add a new Go subgroup and its organizing members

### DIFF
--- a/docs/subgroups.md
+++ b/docs/subgroups.md
@@ -23,3 +23,6 @@ The language-specific subgroups are
 * JavaScript & TypeScript (JS/TS) - organized by
   * Calvin Prewitt (JAF Labs)
   * Saúl Cabrera (Shopify)
+* Go - organized by
+  * Achille Roussel (Stealth Rocket)
+  * Jiaxiao (Joe) Zhou (Microsoft)

--- a/docs/subgroups.md
+++ b/docs/subgroups.md
@@ -1,14 +1,14 @@
 # Subgroups
 
-This document is a proposal to create subgroups of the dynamic languages SIG.
-All subgroups will be viewed as a part of SIG-Dynamic-Languages and adhere to all of its rules.
+This document is a proposal to create subgroups of the guest languages SIG.
+All subgroups will be viewed as a part of SIG-Guest-Languages and adhere to all of its rules.
 
 For a subgroup to be formed, there must be two or more members supporting its creation who have agreed to become its organizing members.
-Organizing members are responsible for scheduling and running, meetings and upholding the Bytecode Alliance Code of Conduct.
+Organizing members are responsible for scheduling and running, meetings and upholding the [Bytecode Alliance Code of Conduct](https://github.com/bytecodealliance/wasi/blob/main/ORG_CODE_OF_CONDUCT.md).
 
 Only one kind of subgroup is proposed initially, but this may be extended by future proposals.
 
-Subgroups and their organizing members are listed in this document. Any proposed subgroups or changes to the organizing members of a subgroup must be submitted as a PR to the governance repository, placed on the agenda for a SIG-Dynamic-Languages at least a week before its next meeting, and accepted by a vote.
+Subgroups and their organizing members are listed in this document. Any proposed subgroups or changes to the organizing members of a subgroup must be submitted as a PR to the governance repository, placed on the agenda for a SIG-Guest-Languages at least a week before its next meeting, and accepted by a vote.
 
 ## Language-Specific Subgroups
 


### PR DESCRIPTION
This PR adds a new Go subgroup and its organizing members. 

It also changes the "dynamic languages" to "guest languages" to be more aligned with the SIG. 

FYI @Kylebrown9 