### PR TITLE
Amend Subgroups.md Document

### DIFF
--- a/docs/subgroups.md
+++ b/docs/subgroups.md
@@ -3,12 +3,12 @@
 This document is a proposal to create subgroups of the guest languages SIG.
 All subgroups will be viewed as a part of SIG-Guest-Languages and adhere to all of its rules.
 
-For a subgroup to be formed, there must be two or more members supporting its creation who have agreed to become its organizing members.
-Organizing members are responsible for scheduling and running, meetings and upholding the [Bytecode Alliance Code of Conduct](https://github.com/bytecodealliance/wasi/blob/main/ORG_CODE_OF_CONDUCT.md).
+For a subgroup to be formed, there must be two or more members supporting its creation who have agreed to become its co-chairs.
+Co-chairs are responsible for scheduling and running, meetings and upholding the [Bytecode Alliance Code of Conduct](https://github.com/bytecodealliance/wasi/blob/main/ORG_CODE_OF_CONDUCT.md).
 
 Only one kind of subgroup is proposed initially, but this may be extended by future proposals.
 
-Subgroups and their organizing members are listed in this document. Any proposed subgroups or changes to the organizing members of a subgroup must be submitted as a PR to the governance repository, placed on the agenda for a SIG-Guest-Languages at least a week before its next meeting, and accepted by a vote.
+Subgroups and their co-chairs are listed in this document. Any proposed subgroups or changes to the co-chairs of a subgroup must be submitted as a PR to this repository, placed on the agenda for a SIG-Guest-Languages at least a week before its next meeting, and accepted by a vote.
 
 ## Language-Specific Subgroups
 
@@ -17,19 +17,19 @@ exist to further the Wasm support for that language.
 
 The language-specific subgroups are
 
-* Python - organized by
+* Python - co-chairs:
   * Joel Dice (Fermyon)
   * Kevin Smith (SingleStore)
-* JavaScript & TypeScript (JS/TS) - organized by
+* JavaScript & TypeScript (JS/TS) - co-chairs:
   * Calvin Prewitt (JAF Labs)
   * Saúl Cabrera (Shopify)
-* Go - organized by
+* Go - co-chairs:
   * Achille Roussel (Stealth Rocket)
   * Jiaxiao (Joe) Zhou (Microsoft) 
-* C#/.net - organized by
+* C#/.net - co-chairs:
   * Timmy Silesmo - (nor²)
   * Scott Waye
   * Danilo (Dan) Chiarlone (Microsoft)
-* Rust - organized by
+* Rust - co-chairs:
   * Peter Huene (Fastly)
   * Alex Crichton (Fermyon)


### PR DESCRIPTION
Propose minor changes and clarifications to the Subgroups.md document.

This proposal will be voted on at the April GL SIG meeting.

At that meeting, we will also need to vote to officially confirm the Rust subgroup since we did not do so when it was initially formed. I apologize for this procedural hiccup. I forgot that we explicitly wrote in this document that a vote was needed.